### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Continuous integration status:
     :alt: Coverage
     :target: https://codecov.io/github/mvantellingen/py-soap-wsse
     
-.. image:: https://pypip.in/version/soap_wsse/badge.svg
+.. image:: https://img.shields.io/pypi/v/soap_wsse.svg
     :target: https://pypi.python.org/pypi/soap_wsse/
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20soap-wsse))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `soap-wsse`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.